### PR TITLE
Refactor/historico acoes

### DIFF
--- a/app/routers/historico_acoes.py
+++ b/app/routers/historico_acoes.py
@@ -1,13 +1,10 @@
-from datetime import date
 import json
 from math import ceil
-from typing import Annotated
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select, extract
 from sqlalchemy.orm import aliased
 
-from app.core.historico_acoes import AcoesEnum
-from app.core.seguranca import descriptografa_cpf, gerar_hash
+from app.core.seguranca import descriptografa_cpf
 from app.schemas.acoes import AcaoPaginationOut
 
 from ..core.permissoes import requer_permissao
@@ -17,7 +14,6 @@ from ..models.models import HistoricoAcoes, Usuario
 acoes_router = APIRouter(
     prefix="/historico_acoes",
     tags=["Histórico de Ações"],
-    # dependencies=[Depends(requer_permissao("admin"))],
 )
 
 router = acoes_router
@@ -28,23 +24,9 @@ router = acoes_router
     summary="Lista ações realizadas por funcionários",
     response_model=AcaoPaginationOut,
     dependencies=[Depends(requer_permissao("admin"))],
-
 )
 def pega_acoes(
     db: conexao_bd,
-    tipo_acao: AcoesEnum | None = Query(default=None),
-    id_ator: int | None = Query(default=None),
-    nome_ator: str | None = Query(default=None),
-    cpf_ator: str | None = Query(default=None),
-    id_alvo: int | None = Query(default=None),
-    nome_alvo: str | None = Query(default=None),
-    cpf_alvo: str | None = Query(default=None),
-    data_inicio: date | None = Query(
-        default=None, description="Filtrar ações a partir desta data"
-    ),
-    data_fim: date | None = Query(
-        default=None, description="Filtrar ações até esta data"
-    ),
     mes: int | None = Query(
         default=None, ge=1, le=12, description="Mês específico para filtrar"
     ),
@@ -57,45 +39,30 @@ def pega_acoes(
         10, ge=1, le=100, description="Quantidade de registros por página (padrão 10)"
     ),
 ):
-    Ator = aliased(Usuario, name="ator")
-    Alvo = aliased(Usuario, name="alvo")
+    ator = aliased(Usuario, name="ator")
+    alvo = aliased(Usuario, name="alvo")
 
     query = (
-        select(HistoricoAcoes, Ator, Alvo)
-        .join(Ator, HistoricoAcoes.usuario_id_ator == Ator.id)
-        .join(Alvo, HistoricoAcoes.usuario_id_alvo == Alvo.id, isouter=True)
+        select(HistoricoAcoes, ator, alvo)
+        .join(ator, HistoricoAcoes.usuario_id_ator == ator.id)
+        .join(alvo, HistoricoAcoes.usuario_id_alvo == alvo.id, isouter=True)
     )
 
-    # filtros de usuário e ação
-    if id_ator is not None:
-        query = query.where(Ator.id == id_ator)
-    if nome_ator is not None:
-        query = query.where(Ator.nome == nome_ator)
-    if cpf_ator is not None:
-        query = query.where(Ator.cpf == cpf_ator)
-    if id_alvo is not None:
-        query = query.where(Alvo.id == id_alvo)
-    if nome_alvo is not None:
-        query = query.where(Alvo.nome == nome_alvo)
-    if cpf_alvo is not None:
-        query = query.where(Alvo.cpf_hash == gerar_hash(cpf_alvo))
-    if tipo_acao is not None:
-        query = query.where(HistoricoAcoes.acao == tipo_acao)
-
-    # filtros por data
-    if data_inicio is not None:
-        query = query.where(HistoricoAcoes.data >= data_inicio)
-    if data_fim is not None:
-        query = query.where(HistoricoAcoes.data <= data_fim)
-
     # filtro por mês/ano
-    if mes is not None:
-        if ano is None:
-            raise HTTPException(
-                400, "Se 'mes' for informado, 'ano' também deve ser fornecido"
-            )
+    if mes is not None and ano is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Se 'mes' for informado, 'ano' também deve ser fornecido",
+        )
+
+    if mes is not None and ano is not None:
         query = query.where(
             extract("month", HistoricoAcoes.data) == mes,
+            extract("year", HistoricoAcoes.data) == ano,
+        )
+
+    elif ano is not None:
+        query = query.where(
             extract("year", HistoricoAcoes.data) == ano,
         )
 

--- a/app/routers/informacoes_gerais.py
+++ b/app/routers/informacoes_gerais.py
@@ -94,9 +94,6 @@ def update_info(
             AcoesEnum.ATUALIZAR_INFOS_GERAIS,
             ator["cpf"],
             1,
-            # info_adicional=InformacoesGeraisDTO.model_validate(
-            #     record, from_attributes=True
-            # ).model_dump_json(),
         )
         return record
     except Exception as e:


### PR DESCRIPTION
Refactor das especificações que o SonarQube pediu:
08 - Reduzir a complexidade cognitiva da função `pega_acoes` de 17 para no máximo 15
09 - Diminuir a quantidade de parâmetros da função `pega_acoes` para no máximo 13
10 - Deixar a variável `Ator` em lower case
11 - Deixar a variável `Alvo` em lower case
12 - Apagar o código comentado em `informacoes_gerais`